### PR TITLE
Update 01-kong-mesh-demo-aio.yaml

### DIFF
--- a/03/01-kong-mesh-demo-aio.yaml
+++ b/03/01-kong-mesh-demo-aio.yaml
@@ -4,8 +4,6 @@ kind: Namespace
 metadata:
   name: kong-mesh-demo
   namespace: kong-mesh-demo
-  annotations:
-    kuma.io/sidecar-injection: enabled
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Annotation for side-car injection on NS level removed. Will add back in the template secion on the deployment level afer Kuma CP is up, to avoid manual pod deletion requirement.